### PR TITLE
Fix/sync mgmt units

### DIFF
--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -274,12 +274,18 @@ def get_wfm_units_for_broken_sdk(api_instance):
     return wrap
 
 
-def handle_activity_codes(unit_id):
-    def wrap(activity_code_id, activity_code):
-        activity_code = activity_code.to_dict()
-        activity_code['id'] = activity_code_id
-        activity_code['management_unit_id'] = unit_id
-        return activity_code
+def handle_activity_codes_and_datetimes(unit_id):
+    def wrap(activity_code_id, unit):
+        unit = unit.to_dict()
+        unit['id'] = unit_id
+        unit['management_unit_id'] = unit_id
+
+        if 'metadata' in unit:
+            if isinstance(unit, dict) and 'date_modified' in unit['metadata']:
+                # Convert to string or will get error from json.dumps when outputting data
+                unit['metadata']['date_modified'] = unit['metadata']['date_modified'].isoformat()
+
+        return unit
     return wrap
 
 
@@ -452,12 +458,13 @@ def sync_management_units(config):
         # don't allow args here
         getter = lambda *args, **kwargs: api_instance.get_workforcemanagement_managementunit_activitycodes(unit_id)
         gen_activitycodes = fetch_all_records(getter, 'activity_codes', FakeBody(), max_pages=1)
-        stream_results(gen_activitycodes, handle_activity_codes(unit_id), 'activity_code', schemas.activity_code,
+        stream_results(gen_activitycodes, handle_activity_codes_and_datetimes(unit_id), 'activity_code', schemas.activity_code,
                        ['id', 'management_unit_id'], first_page)
 
         # don't allow args here
         getter = lambda *args, **kwargs: api_instance.get_workforcemanagement_managementunit_users(unit_id)
         gen_users = fetch_all_records(getter, 'entities', FakeBody(), max_pages=1)
+
         users = stream_results(gen_users, handle_mgmt_users(unit_id), 'management_unit_users',
                                schemas.management_unit_users, ['user_id', 'management_unit_id'], first_page)
 

--- a/tap_purecloud/__init__.py
+++ b/tap_purecloud/__init__.py
@@ -363,7 +363,7 @@ def sync_user_schedules(config, unit_id, user_ids, first_page):
 
         getter = lambda *args, **kwargs: api_instance.post_workforcemanagement_managementunit_schedules_search(
             unit_id, body=body)
-        gen_schedules = fetch_one_page(getter, body, 'user_schedules', max_pages=1)
+        gen_schedules = fetch_all_records(getter, 'user_schedules', body, max_pages=1)
 
         stream_results(gen_schedules, handle_schedule(start_date_s), 'user_schedule', schemas.user_schedule,
                        ['start_date', 'user_id'], first_page)


### PR DESCRIPTION
- Fix bug in `sync_management_units()` to convert a datetime in metadata to a string to avoid an error from `json.dumps()`
- In `sync_user_schedules()` the `fetch_one_page()` function was being used and throwing an error as the `max_pages` argument was being passed which it doesn't accept. Switch to using the `fetch_all_records()` function which does accept that argument.
